### PR TITLE
Refactor items API calls to use API_ENDPOINTS constants

### DIFF
--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -4,6 +4,9 @@ export const API_ENDPOINTS = {
   items: {
     list: `${API_BASE}/items`,
     createItem: `${API_BASE}/items`,
+    deleteItems: `${API_BASE}/items/delete`,
+    refetchItemsMetadata: `${API_BASE}/items/fetch-metadata`,
+    updateItemsTags: `${API_BASE}/items/tags`,
     updateItem: (id: any) => `${API_BASE}/items?item-id=${id}`,
   },
   settings: {

--- a/frontend/src/store/mainStore.ts
+++ b/frontend/src/store/mainStore.ts
@@ -225,7 +225,7 @@ class mainStore {
   };
   deleteItems = async (itemIds: number[]) => {
     return await this.runRequest(
-      '/api/items/delete',
+      API_ENDPOINTS.items.deleteItems,
       'POST',
       {
         'item-ids': itemIds,
@@ -235,7 +235,7 @@ class mainStore {
   };
   refetchItemsMetadata = async (itemIds: number[]) => {
     return await this.runRequest(
-      '/api/items/fetch-metadata',
+      API_ENDPOINTS.items.refetchItemsMetadata,
       'POST',
       {
         'item-ids': itemIds,
@@ -253,7 +253,7 @@ class mainStore {
     newSelectedTagsSome: string[];
   }) => {
     return await this.runRequest(
-      '/api/items/tags',
+      API_ENDPOINTS.items.updateItemsTags,
       'PATCH',
       {
         'item-ids': itemIds,


### PR DESCRIPTION
This PR standardizes item-related API calls by replacing hardcoded URLs with the shared API_ENDPOINTS constants.
The change improves consistency across the codebase and makes endpoint management easier and less error-prone.

Changes
1. Replaced direct item API URLs with `API_ENDPOINTS.*`
2. Aligned inconsistent item routes to a single source of truth
3. No functional behavior changes