### PR TITLE
fix: nested tag deletion

### DIFF
--- a/controllers/TagsDeleteController.php
+++ b/controllers/TagsDeleteController.php
@@ -28,9 +28,21 @@ class TagsDeleteController implements ControllerInterface
 			throw new ValidationException("Tag with ID $tag_id does not exist");
 		}
 
-		// Delete all child tags as well
 		$tags_by_parent = groupTagsByParent($all_tags);
-		$tags_to_delete = [$tag_id, ...$tags_by_parent[$tag_id] ?? []];
+		$tags_to_delete = [];
+		$tag_ids_to_visit = [(int)$tag_id];
+
+		while (!empty($tag_ids_to_visit)) {
+			$current_tag_id = array_pop($tag_ids_to_visit);
+			if (in_array($current_tag_id, $tags_to_delete, true)) {
+				continue;
+			}
+
+			$tags_to_delete[] = $current_tag_id;
+			foreach ($tags_by_parent[$current_tag_id] ?? [] as $child_tag_id) {
+				$tag_ids_to_visit[] = $child_tag_id;
+			}
+		}
 
 		// Delete tags associations with items
 		$repository = ServiceContainer::get(Repository::class);

--- a/controllers/TagsUpdateController.php
+++ b/controllers/TagsUpdateController.php
@@ -24,20 +24,37 @@ class TagsUpdateController implements ControllerInterface
 	{
 		$tag_id = (int)$input['tag-id'];
 
-		if ($input['parent'] === 0) {
+		if ((int)$input['parent'] === 0) {
 			$parent_id = 0;
 		} else {
 			[$parent_id] = processInputTags([$input['parent']]);
-		}
-
-		if ($tag_id === $parent_id) {
-			throw new \Exception('Tag cannot be the same as parent');
 		}
 
 		$tag_title = trim($input['title']);
 		$tag_description = trim($input['description']);
 
 		$repository = ServiceContainer::get(Repository::class);
+		$all_tags = $repository->getTags();
+
+		if (!isset($all_tags[$tag_id])) {
+			throw new \Exception('Tag does not exist');
+		}
+
+		$current_parent_id = $parent_id;
+		$visited_parent_ids = [];
+		while ($current_parent_id !== 0) {
+			if ($current_parent_id === $tag_id) {
+				throw new \Exception('Tag cannot be its own parent or child');
+			}
+
+			if (isset($visited_parent_ids[$current_parent_id]) || !isset($all_tags[$current_parent_id])) {
+				throw new \Exception('Invalid tag parent');
+			}
+
+			$visited_parent_ids[$current_parent_id] = true;
+			$current_parent_id = (int)$all_tags[$current_parent_id]['parent'];
+		}
+
 		$repository->updateTag(
 			$tag_id,
 			$tag_title,

--- a/frontend/src/components/Sidebar/SidebarTag.tsx
+++ b/frontend/src/components/Sidebar/SidebarTag.tsx
@@ -262,7 +262,12 @@ const TagEditForm = ({ tag, setIsEditOpen }: { tag: TagType; setIsEditOpen: (boo
               setNewTagParent(tagID as number);
             }}
             selectedTagIDs={[newTagParent]}
-            excludedTagIDs={[tag.id]}
+            excludedTagIDs={[
+              tag.id,
+              ...store.tagsArray
+                .filter((candidateTag) => candidateTag.fullPathIDs.startsWith(`${tag.fullPathIDs}/`))
+                .map((candidateTag) => candidateTag.id),
+            ]}
           />
         </Field>
         <Field orientation="vertical" className="gap-1.5">

--- a/models/Repository.php
+++ b/models/Repository.php
@@ -416,6 +416,24 @@ class Repository
 		if (!$this->checkTagIndexExists() && !$this->createTagIndex()) {
 			throw new Exception('Failed to create index on tags');
 		}
+
+		if (!$this->repairOrphanedTagParents()) {
+			throw new Exception('Failed to repair orphaned tags');
+		}
+	}
+
+	public function repairOrphanedTagParents(): bool
+	{
+		$stmt = $this->pdo->prepare(
+			'UPDATE tags
+			SET parent = 0, updated_at = :updated_at
+			WHERE parent != 0
+			AND NOT EXISTS (SELECT 1 FROM tags AS parent_tag WHERE parent_tag.id = tags.parent)'
+		);
+
+		return $stmt->execute([
+			':updated_at' => date('Y-m-d H:i:s'),
+		]);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

  Fix nested tag deletion leaving orphaned tags hidden from the sidebar.

  Deleting a parent tag now deletes all of its descendants. Existing tags whose
  parent was deleted are restored to the root during migration, so they become
  visible in the sidebar again.

  Also prevents moving a tag under one of its own descendants, which would create
  a circular hierarchy.

  ## How to reproduce on the old version

  1. Start with a fresh database.
  2. Delete the `Faved` tag.
  3. Refresh the page.

  ### Old behavior

  - `Faved` and its direct child `Docs` are deleted.
  - `Getting started` and `Guides` remain, but their parent (`Docs`) no longer
  exists.
  - Those tags no longer appear in the sidebar, so they cannot be edited or
  deleted there.
  - They may still appear in tag-selection dropdowns.

<img width="1534" height="910" alt="image" src="https://github.com/user-attachments/assets/f51ac398-b03d-4e11-830f-ed9a56f7ef9f" />


  ## New behavior

  - Deleting `Faved` also deletes all of its descendant tags.
  - Previously orphaned tags are moved to the root and shown in the sidebar.